### PR TITLE
Document Integration Testing Using Subdomain Constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ end
 
 That will allow clients to access your API at https://api.yourtotallyamazingstore.com
 
+If you use a routing constraint for your API, be sure to add the
+following to **test/test_helper.rb** in your application to use the
+correct domain for API requests:
+
+```ruby
+class Workarea::IntegrationTest
+  setup do
+    host! host.gsub(/www/, 'api') if self.class.name.include?('Api::')
+  end
+end
+```
+
 ## Configuration
 
 This plugin provides a number of options for configuring its usage...


### PR DESCRIPTION
The README describes how to set up an API using a subdomain constraint,
so the API would be available at `api.yourdomain.com`. However, this
causes all integration tests in the API to fail because the subdomain is
not being used when looking up routes to send requests to. To remedy
this, a note has been added to the README explaining how to configure
`Workarea::IntegrationTest` so that subdomains can be used in the API
without integration tests suddenly failing.

**More Info:** https://discourse.workarea.com/t/build-failing-workarea-api-plugin/1652