### PR TITLE
Add Rake Task For Generating API Documentation

### DIFF
--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -3,7 +3,7 @@ load 'rails/test_unit/testing.rake'
 namespace :workarea do
   namespace :api do
     desc 'Generate Workarea API Documentation'
-    task docs: %i[workarea:prepare] do
+    task generate_docs: :'workarea:prepare' do
       roots = [Workarea::Core::Engine.root] +
                 Workarea::Plugin.installed.map(&:root) +
                 [Rails.root]

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -1,0 +1,20 @@
+load 'rails/test_unit/testing.rake'
+
+namespace :workarea do
+  namespace :api do
+    desc 'Generate Workarea API Documentation'
+    task docs: %i[workarea:prepare] do
+      roots = [Workarea::Core::Engine.root] +
+                Workarea::Plugin.installed.map(&:root) +
+                [Rails.root]
+
+      ENV['GENERATE_API_DOCS'] = 'true'
+
+      Rails::TestUnit::Runner.rake_run(
+        roots
+          .map { |r| FileList["#{r}/test/documentation/**/*_test.rb"] }
+          .reduce(&:+)
+      )
+    end
+  end
+end


### PR DESCRIPTION
The `workarea:api:docs` task will generate all API documentation for all
plugins without the need to set environment variables. Developers should
run this task and commit the results in `doc/api` in order to deploy API
documentation changes to a server.