### PR TITLE
Fix Docs Generator Task Name

### DIFF
--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -1,9 +1,9 @@
 load 'rails/test_unit/testing.rake'
 
 namespace :workarea do
-  namespace :api do
+  namespace :test do
     desc 'Generate Workarea API Documentation'
-    task generate_docs: :'workarea:prepare' do
+    task api_docs: :'workarea:prepare' do
       roots = [Workarea::Core::Engine.root] +
                 Workarea::Plugin.installed.map(&:root) +
                 [Rails.root]


### PR DESCRIPTION
The task name `workarea:api:generate_docs` wasn't able to load the
environment like the rest of the `workarea:test` tasks because it wasn't
in the correct Rake namespace. This is due to a hack in core that
configures the Rake environment such that custom Rake tasks for testing
are possible. Change the task name to `workarea:test:api_docs` to take
advantage of this hack so the tests will run properly.