### PR TITLE
Ensure DateFiltering is included in models

### DIFF
--- a/admin/app/models/workarea/content.decorator
+++ b/admin/app/models/workarea/content.decorator
@@ -1,0 +1,7 @@
+module Workarea
+  decorate Content, with: :api_admin do
+    decorated do
+      include Workarea::Api::Admin::DateFiltering
+    end
+  end
+end

--- a/admin/app/models/workarea/release.decorator
+++ b/admin/app/models/workarea/release.decorator
@@ -1,0 +1,7 @@
+module Workarea
+  decorate Release, with: :api_admin do
+    decorated do
+      include Workarea::Api::Admin::DateFiltering
+    end
+  end
+end


### PR DESCRIPTION
To avoid a missing `by_updated_at` method error in tests, explicitly
`decorate` the models that may autoload `ApplicationDocument` prior to
the API's engine initializer getting called.

**NOTE:** This change should be more apparent in mega-build or an actual
app, since the tests don't fail when running locally.