### PR TITLE
Fix Caching in JBuilder Templates

### DIFF
--- a/storefront/lib/workarea/api/storefront.rb
+++ b/storefront/lib/workarea/api/storefront.rb
@@ -14,3 +14,4 @@ end
 require 'workarea/api/version'
 require 'workarea/api/storefront/engine'
 require 'workarea/api/storefront/visit.decorator'
+require 'workarea/api/storefront/ext/freedom_patches/jbuilder_template_cache'

--- a/storefront/lib/workarea/api/storefront/ext/freedom_patches/jbuilder_template_cache.rb
+++ b/storefront/lib/workarea/api/storefront/ext/freedom_patches/jbuilder_template_cache.rb
@@ -1,0 +1,17 @@
+class JbuilderTemplate < Jbuilder
+  def _cache_fragment_for(key, options, &block)
+    return super(key, options) unless workarea_admin_accessing_api_route?
+
+    key = _cache_key(key, options)
+
+    _write_fragment_cache(key, options, &block)
+  end
+
+  private
+
+  def workarea_admin_accessing_api_route?
+    @context.controller.is_a?(::Workarea::Api::Storefront::ApplicationController) &&
+      @context.controller.authentication? &&
+        @context.controller.current_user.admin?
+  end
+end


### PR DESCRIPTION
To resolve an issue where cached data would still appear in Jbuilder templates even when requesting as a logged-in admin, override the `JbuilderTemplate#cache!` method to perform the same checks as the `ActionView::Helpers::WorkareaCache` helper when rendering pages as HTML. This ensures that data between API requests and regular HTML requests on the storefront are consistent. The patch is only active for Storefront API controllers, as Jbuilder is used extensively elsewhere and this kind of cache lookup wouldn't work in those contexts.