### PR TITLE
Handle non-persisted recommendation settings

### DIFF
--- a/admin/app/controllers/workarea/api/admin/recommendation_settings_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/recommendation_settings_controller.rb
@@ -114,7 +114,7 @@ module Workarea
         private
 
         def find_recommendation_settings
-          @recommendation_settings = Recommendation::Settings.find(params[:product_id])
+          @recommendation_settings = Recommendation::Settings.find_or_initialize_by(id: params[:product_id])
         end
       end
     end

--- a/admin/test/integration/workarea/api/admin/recommendation_settings_integration_test.rb
+++ b/admin/test/integration/workarea/api/admin/recommendation_settings_integration_test.rb
@@ -35,6 +35,20 @@ module Workarea
 
           assert_equal(['foo'], recommendation_settings.reload.product_ids)
         end
+
+        def test_unpersisted_recommendation_settings
+          get admin_api.product_recommendation_settings_path(@product.id)
+          result = JSON.parse(response.body)['recommendation_settings']
+          assert_equal(@product.id, result['_id'])
+          assert_equal(0, Recommendation::Settings.count)
+
+          patch admin_api.product_recommendation_settings_path(@product.id),
+            params: { recommendation_settings: { product_ids: ['foo'] } }
+
+          assert_equal(1, Recommendation::Settings.count)
+          assert_equal(@product.id, Recommendation::Settings.first.id)
+          assert_equal(['foo'], Recommendation::Settings.first.product_ids)
+        end
       end
     end
   end


### PR DESCRIPTION
This uses `find_or_initialize` to match our usage of
`Recommendation::Settings` elsewhere in the platform.

Fixes #19