### PR TITLE
Fix Checkout Update Response

### DIFF
--- a/storefront/app/models/workarea/checkout.decorator
+++ b/storefront/app/models/workarea/checkout.decorator
@@ -1,0 +1,7 @@
+module Workarea
+  decorate Checkout, with: :storefront_api do
+    def update(params = {})
+      steps.all? { |s| s.new(self).update(params) }
+    end
+  end
+end

--- a/storefront/test/integration/workarea/api/storefront/checkouts_integration_test.rb
+++ b/storefront/test/integration/workarea/api/storefront/checkouts_integration_test.rb
@@ -94,6 +94,17 @@ module Workarea
             params: {
               email: 'test@workarea.com',
               shipping_address: address,
+              shipping_service: 'Express'
+            }
+          shipping = Shipping.find_by_order(@order.id)
+
+          assert_response(:unprocessable_entity)
+          assert_equal('Express', shipping.shipping_service.name)
+
+          patch storefront_api.checkout_path(@order),
+            params: {
+              email: 'test@workarea.com',
+              shipping_address: address,
               billing_address: address,
             }
 


### PR DESCRIPTION
Consumers of the Checkouts API expect a 422 response when a failure occurs for any reason. Previously, Workarea was always returnin ga 200 success even when the update could not be fully completed. To resolve this, the `Workarea::Checkout#update` method has been modified to return `false` when the update fails, triggering the proper status code in the response.

**edit:** this is a deja vu PR as the history of v4.5-stable changed. just wanted to make sure it still passes tests.