### PR TITLE
Add Documentation Test for Failed Checkout Update

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,8 @@ rescue LoadError
 end
 
 require 'rails'
+require "action_view/railtie"
+
 require 'workarea/core'
 require 'rake/testtask'
 require 'date'

--- a/storefront/test/documentation/workarea/api/storefront/checkouts_documentation_test.rb
+++ b/storefront/test/documentation/workarea/api/storefront/checkouts_documentation_test.rb
@@ -85,6 +85,27 @@ module Workarea
           end
         end
 
+        def test_and_document_update_failure
+          description 'Failure to update a checkout'
+          route storefront_api.checkout_path(':id')
+          explanation <<-EOS
+            This is an example of what occurs when you fail to send in the correct parameters for your checkout.
+          EOS
+
+          record_request do
+            patch storefront_api.checkout_path(@order),
+              as: :json,
+              params: {
+                email: 'susanb@workarea.com',
+                shipping_address: address.except(:first_name),
+                billing_address: address.except(:last_name),
+                shipping_service: 'Express'
+              }
+
+            assert_equal(422, response.status)
+          end
+        end
+
         def test_and_document_complete
           description 'Completing a checkout'
           route storefront_api.complete_checkout_path(':id')

--- a/storefront/test/documentation/workarea/api/storefront/validation_documentation_test.rb
+++ b/storefront/test/documentation/workarea/api/storefront/validation_documentation_test.rb
@@ -72,7 +72,7 @@ module Workarea
                 }
               }
 
-            assert_equal(200, response.status)
+            assert_equal(422, response.status)
           end
         end
       end


### PR DESCRIPTION
This documents the scenario in which a checkout update fails to persist,
and thus the API returns a `422` error to signify its failure. It
depends on the code changes in workarea-commerce/workarea#481, and thus
we will need to bump the Workarea version to restrict its upgrade to
users of v3.5.17 and beyond.