### PR TITLE
Ensure Port Is Not Specified In Storefront API URL Helper

### DIFF
--- a/storefront/app/helpers/workarea/api/storefront/application_helper.rb
+++ b/storefront/app/helpers/workarea/api/storefront/application_helper.rb
@@ -3,10 +3,12 @@ module Workarea
     module Storefront
       module ApplicationHelper
         def storefront_api_url_for(taxon)
+          port = Rails.env.development? ? request.port : nil
+
           if taxon.url?
             taxon.url
           elsif taxon.navigable?
-            send("#{taxon.resource_name}_url", taxon.navigable_slug)
+            send("#{taxon.resource_name}_url", taxon.navigable_slug, port: port)
           end
         end
       end

--- a/storefront/test/helpers/workarea/api/storefront/application_helper_test.rb
+++ b/storefront/test/helpers/workarea/api/storefront/application_helper_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module Workarea
+  module Api
+    module Storefront
+      class ApplicationHelperTest < ViewTest
+        include Engine.routes.url_helpers
+
+        def test_storefront_api_url_for
+          navigable = create_page
+          taxon = create_taxon(navigable: navigable)
+
+          refute_includes(storefront_api_url_for(taxon), ':3000')
+        end
+
+        private
+
+        def default_url_options(*)
+          { host: 'example.com' }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In some QA/Staging environments, generated URLs in the API include an incorrect port (`:3000`). This is caused by the fact that the Rails server is running in a container, bound to port 3000, and the `request.port` is different from the normal 80/443 defaults, thus Rails automatically specifies it as part of the URL. To get around this, always pass in a custom `:port` to the URL helper method that is called as part of `storefront_api_url_for`. In non-development environments, this port will always be `nil`, but for development `:3000` will still be used for those who use a local Rails server for development at `localhost:3000`.