### PR TITLE
Move creation of date filtering indexes to after initialize

### DIFF
--- a/admin/app/models/workarea/api/admin/date_filtering.rb
+++ b/admin/app/models/workarea/api/admin/date_filtering.rb
@@ -4,9 +4,6 @@ module Workarea
       module DateFiltering
         extend ActiveSupport::Concern
         included do
-          index({ updated_at: 1 })
-          index({ created_at: 1 })
-
           scope :by_updated_at, ->(starts_at:, ends_at:) do
             query = criteria
             query = query.where(:updated_at.gte => starts_at) unless starts_at.nil?

--- a/admin/lib/workarea/api/admin.rb
+++ b/admin/lib/workarea/api/admin.rb
@@ -19,3 +19,4 @@ end
 require 'workarea/api/version'
 require 'workarea/api/admin/engine'
 require 'workarea/api/admin/swagger'
+require 'workarea/api/admin/date_indexes'

--- a/admin/lib/workarea/api/admin/date_indexes.rb
+++ b/admin/lib/workarea/api/admin/date_indexes.rb
@@ -1,0 +1,23 @@
+
+module Workarea
+  module Api
+    module Admin
+      module DateIndexes
+        extend self
+
+        # We do this separately from the DateFiltering module to ensure
+        # this happens after a model has defined all of its normal indexes. This
+        # prevents the date filtering indexes from applying before explicity
+        # defined indexes for models that could include options like a TTL.
+        def load
+          ::Mongoid.models.each do |model|
+            if model < ApplicationDocument
+              model.index({ updated_at: 1 })
+              model.index({ created_at: 1 })
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/admin/lib/workarea/api/admin/engine.rb
+++ b/admin/lib/workarea/api/admin/engine.rb
@@ -14,10 +14,12 @@ module Workarea
 
         config.after_initialize do
           Workarea::Api::Admin::Swagger.generate!
+          Workarea::Api::Admin::DateIndexes.load
         end
 
         config.to_prepare do
           ApplicationDocument.include(DateFiltering)
+          Workarea::Api::Admin::DateIndexes.load
         end
       end
     end


### PR DESCRIPTION
The DateFiltering module that the admin API adds to ApplicationDocument
could cause some indexes on created_at or updated_at to be ignored
unexpectedly since DateFiltering had already added indexes for those
fields. Moving the creation of those indexes to after initialization
ensures the model can define its own indexes first.

API-17