### PR TITLE
Ruby 3.x compatibility: replace deprecated APIs, update gemspec ruby constraint

### DIFF
--- a/admin/app/controllers/workarea/api/admin/categories_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/categories_controller.rb
@@ -253,7 +253,7 @@ module Workarea
         end
 
         def update
-          @category.update_attributes!(params[:category])
+          @category.update!(params[:category])
           respond_with category: @category
         end
 

--- a/admin/app/controllers/workarea/api/admin/category_product_rules_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/category_product_rules_controller.rb
@@ -208,7 +208,7 @@ module Workarea
         end
 
         def update
-          @product_rule.update_attributes!(params[:product_rule])
+          @product_rule.update!(params[:product_rule])
           respond_with product_rule: @product_rule
         end
 

--- a/admin/app/controllers/workarea/api/admin/content_assets_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/content_assets_controller.rb
@@ -250,7 +250,7 @@ module Workarea
         end
 
         def update
-          @asset.update_attributes!(params[:asset])
+          @asset.update!(params[:asset])
           respond_with asset: @asset
         end
 

--- a/admin/app/controllers/workarea/api/admin/content_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/content_controller.rb
@@ -221,7 +221,7 @@ module Workarea
         end
 
         def update
-          @content.update_attributes!(params[:content])
+          @content.update!(params[:content])
           respond_with content: @content
         end
 

--- a/admin/app/controllers/workarea/api/admin/discounts_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/discounts_controller.rb
@@ -258,7 +258,7 @@ module Workarea
         end
 
         def update
-          @discount.update_attributes!(params[:discount])
+          @discount.update!(params[:discount])
           respond_with discount: @discount
         end
 

--- a/admin/app/controllers/workarea/api/admin/fulfillment_skus_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/fulfillment_skus_controller.rb
@@ -254,7 +254,7 @@ module Workarea
         end
 
         def update
-          @fulfillment_sku.update_attributes!(params[:fulfillment_sku])
+          @fulfillment_sku.update!(params[:fulfillment_sku])
           respond_with fulfillment_sku: @fulfillment_sku
         end
 

--- a/admin/app/controllers/workarea/api/admin/inventory_skus_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/inventory_skus_controller.rb
@@ -254,7 +254,7 @@ module Workarea
         end
 
         def update
-          @inventory_sku.update_attributes!(params[:inventory_sku])
+          @inventory_sku.update!(params[:inventory_sku])
           respond_with inventory_sku: @inventory_sku
         end
 

--- a/admin/app/controllers/workarea/api/admin/navigation_menus_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/navigation_menus_controller.rb
@@ -254,7 +254,7 @@ module Workarea
         end
 
         def update
-          @navigation_menu.update_attributes!(params[:navigation_menu])
+          @navigation_menu.update!(params[:navigation_menu])
           respond_with navigation_menu: @navigation_menu
         end
 

--- a/admin/app/controllers/workarea/api/admin/navigation_taxons_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/navigation_taxons_controller.rb
@@ -254,7 +254,7 @@ module Workarea
         end
 
         def update
-          @navigation_taxon.update_attributes!(params[:navigation_taxon])
+          @navigation_taxon.update!(params[:navigation_taxon])
           respond_with navigation_taxon: @navigation_taxon
         end
 

--- a/admin/app/controllers/workarea/api/admin/pages_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/pages_controller.rb
@@ -254,7 +254,7 @@ module Workarea
         end
 
         def update
-          @page.update_attributes!(params[:page])
+          @page.update!(params[:page])
           respond_with page: @page
         end
 

--- a/admin/app/controllers/workarea/api/admin/payment_profiles_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/payment_profiles_controller.rb
@@ -254,7 +254,7 @@ module Workarea
         end
 
         def update
-          @payment_profile.update_attributes!(params[:payment_profile])
+          @payment_profile.update!(params[:payment_profile])
           respond_with payment_profile: @payment_profile
         end
 

--- a/admin/app/controllers/workarea/api/admin/prices_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/prices_controller.rb
@@ -208,7 +208,7 @@ module Workarea
         end
 
         def update
-          @price.update_attributes!(params[:price])
+          @price.update!(params[:price])
           respond_with price: @price
         end
 

--- a/admin/app/controllers/workarea/api/admin/pricing_skus_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/pricing_skus_controller.rb
@@ -254,7 +254,7 @@ module Workarea
         end
 
         def update
-          @pricing_sku.update_attributes!(params[:pricing_sku])
+          @pricing_sku.update!(params[:pricing_sku])
           respond_with pricing_sku: @pricing_sku
         end
 

--- a/admin/app/controllers/workarea/api/admin/product_images_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/product_images_controller.rb
@@ -208,7 +208,7 @@ module Workarea
         end
 
         def update
-          @image.update_attributes!(params[:image])
+          @image.update!(params[:image])
           respond_with image: @image
         end
 

--- a/admin/app/controllers/workarea/api/admin/products_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/products_controller.rb
@@ -254,7 +254,7 @@ module Workarea
         end
 
         def update
-          @product.update_attributes!(params[:product])
+          @product.update!(params[:product])
           respond_with product: @product
         end
 

--- a/admin/app/controllers/workarea/api/admin/promo_code_lists_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/promo_code_lists_controller.rb
@@ -254,7 +254,7 @@ module Workarea
         end
 
         def update
-          @promo_code_list.update_attributes!(params[:promo_code_list])
+          @promo_code_list.update!(params[:promo_code_list])
           respond_with promo_code_list: @promo_code_list
         end
 

--- a/admin/app/controllers/workarea/api/admin/recommendation_settings_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/recommendation_settings_controller.rb
@@ -107,7 +107,7 @@ module Workarea
         end
 
         def update
-          @recommendation_settings.update_attributes!(params[:recommendation_settings])
+          @recommendation_settings.update!(params[:recommendation_settings])
           respond_with recommendation_settings: @recommendation_settings
         end
 

--- a/admin/app/controllers/workarea/api/admin/redirects_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/redirects_controller.rb
@@ -254,7 +254,7 @@ module Workarea
         end
 
         def update
-          @redirect.update_attributes!(params[:redirect])
+          @redirect.update!(params[:redirect])
           respond_with redirect: @redirect
         end
 

--- a/admin/app/controllers/workarea/api/admin/releases_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/releases_controller.rb
@@ -253,7 +253,7 @@ module Workarea
         end
 
         def update
-          @release.update_attributes!(params[:release])
+          @release.update!(params[:release])
           respond_with release: @release
         end
 

--- a/admin/app/controllers/workarea/api/admin/saved_addresses_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/saved_addresses_controller.rb
@@ -208,7 +208,7 @@ module Workarea
         end
 
         def update
-          @saved_address.update_attributes!(params[:saved_address])
+          @saved_address.update!(params[:saved_address])
           respond_with saved_address: @saved_address
         end
 

--- a/admin/app/controllers/workarea/api/admin/saved_credit_cards_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/saved_credit_cards_controller.rb
@@ -219,7 +219,7 @@ module Workarea
         end
 
         def update
-          @saved_credit_card.update_attributes!(params[:saved_credit_card])
+          @saved_credit_card.update!(params[:saved_credit_card])
           respond_with saved_credit_card: @saved_credit_card
         end
 

--- a/admin/app/controllers/workarea/api/admin/shipping_rates_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/shipping_rates_controller.rb
@@ -208,7 +208,7 @@ module Workarea
         end
 
         def update
-          @rate.update_attributes!(params[:rate])
+          @rate.update!(params[:rate])
           respond_with rate: @rate
         end
 

--- a/admin/app/controllers/workarea/api/admin/shipping_services_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/shipping_services_controller.rb
@@ -251,7 +251,7 @@ module Workarea
         end
 
         def update
-          @shipping_service.update_attributes!(params[:shipping_service])
+          @shipping_service.update!(params[:shipping_service])
           respond_with shipping_service: @shipping_service
         end
 

--- a/admin/app/controllers/workarea/api/admin/shipping_skus_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/shipping_skus_controller.rb
@@ -254,7 +254,7 @@ module Workarea
         end
 
         def update
-          @shipping_sku.update_attributes!(params[:shipping_sku])
+          @shipping_sku.update!(params[:shipping_sku])
           respond_with shipping_sku: @shipping_sku
         end
 

--- a/admin/app/controllers/workarea/api/admin/tax_categories_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/tax_categories_controller.rb
@@ -186,7 +186,7 @@ module Workarea
         end
 
         def update
-          @tax_category.update_attributes!(params[:tax_category])
+          @tax_category.update!(params[:tax_category])
           respond_with tax_category: @tax_category
         end
 

--- a/admin/app/controllers/workarea/api/admin/tax_rates_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/tax_rates_controller.rb
@@ -217,7 +217,7 @@ module Workarea
         end
 
         def update
-          @tax_rate.update_attributes!(params[:rate])
+          @tax_rate.update!(params[:rate])
           respond_with rate: @tax_rate
         end
 

--- a/admin/app/controllers/workarea/api/admin/users_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/users_controller.rb
@@ -247,7 +247,7 @@ module Workarea
         end
 
         def update
-          @user.update_attributes!(params[:user])
+          @user.update!(params[:user])
           respond_with user: api_attributes_for(@user)
         end
 

--- a/admin/app/controllers/workarea/api/admin/variants_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/variants_controller.rb
@@ -208,7 +208,7 @@ module Workarea
         end
 
         def update
-          @variant.update_attributes!(params[:variant])
+          @variant.update!(params[:variant])
           respond_with variant: @variant
         end
 

--- a/admin/test/documentation/workarea/api/admin/email_signups_documentation_test.rb
+++ b/admin/test/documentation/workarea/api/admin/email_signups_documentation_test.rb
@@ -43,7 +43,7 @@ module Workarea
           signup = create_email_signup(email: 'test@workarea.com')
 
           record_request do
-            get admin_api.email_signup_path(URI.escape(signup.email, '+@.'))
+            get admin_api.email_signup_path(CGI.escape(signup.email))
             assert_equal(200, response.status)
           end
         end

--- a/admin/test/documentation/workarea/api/admin/users_documentation_test.rb
+++ b/admin/test/documentation/workarea/api/admin/users_documentation_test.rb
@@ -63,7 +63,7 @@ module Workarea
           user = create_user(email: 'test@workarea.com')
 
           record_request do
-            get admin_api.user_path(URI.escape(user.email, '+@.'))
+            get admin_api.user_path(CGI.escape(user.email))
             assert_equal(200, response.status)
           end
         end

--- a/admin/test/integration/workarea/api/admin/email_signups_integration_test.rb
+++ b/admin/test/integration/workarea/api/admin/email_signups_integration_test.rb
@@ -59,7 +59,7 @@ module Workarea
           result = JSON.parse(response.body)['email_signup']
           assert_equal(email_signup, Email::Signup.new(result))
 
-          get admin_api.email_signup_path(URI.escape(email_signup.email, '+@.'))
+          get admin_api.email_signup_path(CGI.escape(email_signup.email))
           result = JSON.parse(response.body)['email_signup']
           assert_equal(email_signup, Email::Signup.new(result))
         end

--- a/admin/test/integration/workarea/api/admin/users_integration_test.rb
+++ b/admin/test/integration/workarea/api/admin/users_integration_test.rb
@@ -78,7 +78,7 @@ module Workarea
           assert(result['password_digest'].blank?)
           assert_equal(user, User.new(result))
 
-          get admin_api.user_path(URI.escape(user.email, '+@.'))
+          get admin_api.user_path(CGI.escape(user.email))
           result = JSON.parse(response.body)['user']
           assert(result['password_digest'].blank?)
           assert_equal(user, User.new(result))

--- a/storefront/app/controllers/workarea/api/storefront/accounts_controller.rb
+++ b/storefront/app/controllers/workarea/api/storefront/accounts_controller.rb
@@ -16,7 +16,7 @@ module Workarea
         end
 
         def update
-          current_user.update_attributes!(user_params)
+          current_user.update!(user_params)
           render :show
         end
 

--- a/storefront/app/controllers/workarea/api/storefront/saved_addresses_controller.rb
+++ b/storefront/app/controllers/workarea/api/storefront/saved_addresses_controller.rb
@@ -18,7 +18,7 @@ module Workarea
         def update
           @address = current_user.addresses.find(params[:id])
 
-          @address.update_attributes!(address_params)
+          @address.update!(address_params)
           render :show
         end
 

--- a/storefront/app/controllers/workarea/api/storefront/saved_credit_cards_controller.rb
+++ b/storefront/app/controllers/workarea/api/storefront/saved_credit_cards_controller.rb
@@ -20,7 +20,7 @@ module Workarea
         def update
           @credit_card = @payment_profile.credit_cards.find(params[:id])
 
-          @credit_card.update_attributes!(card_params)
+          @credit_card.update!(card_params)
           render :show
         end
 

--- a/storefront/test/integration/workarea/api/storefront/authentication_tokens_integration_test.rb
+++ b/storefront/test/integration/workarea/api/storefront/authentication_tokens_integration_test.rb
@@ -50,7 +50,7 @@ module Workarea
 
           assert(response.ok?)
 
-          @user.update_attributes!(password: 'a_different_password')
+          @user.update!(password: 'a_different_password')
 
           get storefront_api.account_path,
             headers: { 'HTTP_AUTHORIZATION' => encode_credentials(token) }

--- a/storefront/test/integration/workarea/api/storefront/cart_items_integration_test.rb
+++ b/storefront/test/integration/workarea/api/storefront/cart_items_integration_test.rb
@@ -63,7 +63,7 @@ module Workarea
         end
 
         def test_create_with_inactive_sku
-          @product.variants.first.update_attributes!(active: false)
+          @product.variants.first.update!(active: false)
 
           post storefront_api.cart_items_path(@order),
             params: {
@@ -80,7 +80,7 @@ module Workarea
         end
 
         def test_create_with_customizations
-          @product.update_attributes(customizations: 'foo_cust')
+          @product.update(customizations: 'foo_cust')
 
           post storefront_api.cart_items_path(@order),
             params: {
@@ -100,7 +100,7 @@ module Workarea
         end
 
         def test_create_with_invalid_customizations
-          @product.update_attributes(customizations: 'foo_cust')
+          @product.update(customizations: 'foo_cust')
 
           post storefront_api.cart_items_path(@order),
             params: {

--- a/storefront/test/integration/workarea/api/storefront/carts_integration_test.rb
+++ b/storefront/test/integration/workarea/api/storefront/carts_integration_test.rb
@@ -56,7 +56,7 @@ module Workarea
 
           # don't allow users to grab other users's checkouts
           other_user = create_user
-          @order.update_attributes!(user_id: other_user.id)
+          @order.update!(user_id: other_user.id)
 
           get storefront_api.cart_path(@order),
             headers: { 'HTTP_AUTHORIZATION' => encode_credentials(auth.token) }
@@ -83,7 +83,7 @@ module Workarea
         end
 
         def test_purchasable_items
-          @product.variants.first.update_attributes!(active: false)
+          @product.variants.first.update!(active: false)
 
           get storefront_api.cart_path(@order)
           result = JSON.parse(response.body)

--- a/storefront/test/integration/workarea/api/storefront/searches_integration_test.rb
+++ b/storefront/test/integration/workarea/api/storefront/searches_integration_test.rb
@@ -5,7 +5,7 @@ module Workarea
     module Storefront
       class SearchesIntegrationTest < IntegrationTest
         def test_shows_search_results
-          Search::Settings.current.update_attributes!(terms_facets: %w(Color Size))
+          Search::Settings.current.update!(terms_facets: %w(Color Size))
           create_product(
             id: 'PRODUCT1',
             name: 'Pretty Nice Shirt',
@@ -49,7 +49,7 @@ module Workarea
         end
 
         def test_shows_no_search_results
-          Search::Settings.current.update_attributes!(terms_facets: %w(Color Size))
+          Search::Settings.current.update!(terms_facets: %w(Color Size))
           create_product(
             id: 'PRODUCT1',
             name: 'Pretty Nice Shirt',

--- a/storefront/test/integration/workarea/api/storefront/taxons_integration_test.rb
+++ b/storefront/test/integration/workarea/api/storefront/taxons_integration_test.rb
@@ -29,7 +29,7 @@ module Workarea
         end
 
         def test_inactive_taxon
-          @taxon.update_attributes!(
+          @taxon.update!(
             url: nil,
             navigable: create_page(active: false)
           )

--- a/workarea-api.gemspec
+++ b/workarea-api.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.license = 'Business Software License'
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.7', '< 3.5'
 
   s.add_dependency 'workarea', '~> 3.x', '>= 3.5.x'
   s.add_dependency 'workarea-api-storefront', Workarea::Api::VERSION


### PR DESCRIPTION
## Ruby 3.x Compatibility

### Changes
- Replace `update_attributes`/`update_attributes!` with `update`/`update!` (removed in Rails 6.1+)
- Update `required_ruby_version` in gemspec to `'>= 2.7', '< 3.5'`

### Verification
```sh
grep -rn 'update_attributes\|Dir\.exists?\|URI\.escape' --include='*.rb' . | grep -v vendor
# Returns no output
```

### Related
Closes workarea-commerce/workarea#676

Client impact: None — backward compatible